### PR TITLE
"Attach to process" dialog improvements. (#1081)

### DIFF
--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/AttachToProcess/AttachToProcessVM.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/AttachToProcess/AttachToProcessVM.cs
@@ -57,6 +57,17 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 
 		public string Title { get; }
 
+		public override bool HasError => hasError;
+		bool hasError;
+
+		void UpdateHasError() {
+			var value = SelectedItems.Count == 0;
+			if (hasError != value) {
+				hasError = value;
+				HasErrorUpdated();
+			}
+		}
+
 		public bool HasMessageText => !string.IsNullOrEmpty(MessageText);
 		public string MessageText { get; }
 
@@ -103,6 +114,7 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 			realAllItems = new ObservableCollection<ProgramVM>();
 			AllItems = new BulkObservableCollection<ProgramVM>();
 			SelectedItems = new ObservableCollection<ProgramVM>();
+			SelectedItems.CollectionChanged += (_, e) => { UpdateHasError(); };
 			this.uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
 			uiDispatcher.VerifyAccess();
 			this.dbgManager = dbgManager ?? throw new ArgumentNullException(nameof(dbgManager));
@@ -127,6 +139,7 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 			};
 			Descs.SortedColumnChanged += (a, b) => SortList();
 
+			UpdateHasError();
 			RefreshCore();
 		}
 
@@ -243,6 +256,8 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 				filterText = string.Empty;
 			attachToProcessContext.SearchMatcher.SetSearchText(filterText);
 			SortList(filterText);
+			if (SelectedItems.Count == 0 && AllItems.Count > 0)
+				SelectedItems.Add(AllItems[0]);
 		}
 
 		void SortList() {

--- a/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/AttachToProcess/ShowAttachToProcessDialogImpl.cs
+++ b/Extensions/dnSpy.Debugger/dnSpy.Debugger/Dialogs/AttachToProcess/ShowAttachToProcessDialogImpl.cs
@@ -40,6 +40,7 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 		readonly Lazy<DebuggerSettings> debuggerSettings;
 		readonly Lazy<ProgramFormatterProvider> programFormatterProvider;
 		readonly IMessageBoxService messageBoxService;
+		string lastFilterText;
 
 		[ImportingConstructor]
 		ShowAttachToProcessDialogImpl(IAppWindow appWindow, Lazy<UIDispatcher> uiDispatcher, IClassificationFormatMapService classificationFormatMapService, ITextElementProvider textElementProvider, Lazy<AttachProgramOptionsAggregatorFactory> attachProgramOptionsAggregatorFactory, Lazy<DbgManager> dbgManager, Lazy<DebuggerSettings> debuggerSettings, Lazy<ProgramFormatterProvider> programFormatterProvider, IMessageBoxService messageBoxService) {
@@ -59,11 +60,13 @@ namespace dnSpy.Debugger.Dialogs.AttachToProcess {
 			try {
 				var dlg = new AttachToProcessDlg();
 				vm = new AttachToProcessVM(options, uiDispatcher.Value, dbgManager.Value, debuggerSettings.Value, programFormatterProvider.Value, classificationFormatMapService, textElementProvider, attachProgramOptionsAggregatorFactory.Value, () => SearchHelp(vm, dlg));
+				vm.FilterText = lastFilterText;
 				dlg.DataContext = vm;
 				dlg.Owner = appWindow.MainWindow;
 				var res = dlg.ShowDialog();
 				if (res != true)
 					return Array.Empty<AttachToProgramOptions>();
+				lastFilterText = vm.FilterText;
 				return vm.SelectedItems.Select(a => a.AttachProgramOptions.GetOptions()).ToArray();
 			}
 			finally {


### PR DESCRIPTION
* "Attact to process" dialog improvements.
Automatically select first item if user filters the list.
Save/load last filter text user entered in the dialog.
Disable "OK" button if user haven't select any processes.

* Clean up.